### PR TITLE
Fixed wordcloud Python module requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ requests
 seaborn
 spacy
 tldextract
-word_cloud
+wordcloud


### PR DESCRIPTION
"word_cloud" doesn't exist, and the scripts refer to "wordcloud". Updated requirements.txt to match